### PR TITLE
Revert "Install-ISHDotNetHosting for 14.0.3"

### DIFF
--- a/Source/Server/ISHServer/Install-ISHServerPrerequisites.ps1
+++ b/Source/Server/ISHServer/Install-ISHServerPrerequisites.ps1
@@ -68,7 +68,6 @@ try
     {
         Install-ISHToolAdoptOpenJRE
         Install-ISHToolAdoptOpenJDK
-        Install-ISHDotNetHosting
     }
     else
     {
@@ -80,6 +79,10 @@ try
     if($InstallOracle)
     {
         Install-ISHToolOracleODAC
+    }
+    if($ISHServerVersion -eq "15")
+    {
+        Install-ISHDotNetHosting 
     }
     Write-Progress @scriptProgress -Status "Initializing"
     Initialize-ISHLocale


### PR DESCRIPTION
Reverts sdl/ISHBootstrap#132
.NET Core 3.1 (Hosting Bundle) is no longer a requirement for 14.0.3